### PR TITLE
Ability to add amounts in dolar sign

### DIFF
--- a/src/components/BatchTx/useBatchConfig.ts
+++ b/src/components/BatchTx/useBatchConfig.ts
@@ -38,7 +38,7 @@ const batchColumns: {
     label: 'Amount',
     canDeselect: false,
     parser: (amount: string, { asset }: { asset: IAssetStorageItem }) =>
-      ethers.utils.parseUnits(amount.split(',').join(''), asset.decimals).toString(),
+      ethers.utils.parseUnits(amount.split(',').join('').split('$').join(''), asset.decimals).toString(),
   },
   notes: {
     name: 'notes',


### PR DESCRIPTION
Users can enter amount in dolar sign parser will just ignore it. 
![image](https://user-images.githubusercontent.com/34207598/177109003-de949615-2fb3-447f-9910-b7d4b8ef2d3d.png)
